### PR TITLE
ノードの色を決める関数をローカル関数に。

### DIFF
--- a/customize_demo.html
+++ b/customize_demo.html
@@ -56,11 +56,13 @@
           nodes: [
             {
               id: 'a',
+              group: 2,
               title: 'Title A',
               year: 1998
             },
             {
               id: 'c',
+              group: 3,
               title: 'Title C',
               year: 2001
             }
@@ -72,7 +74,7 @@
               targetNodeId: 'a'
             }
           ]
-        }; 
+        };
         this.$.force.load(data);
       }
     });

--- a/fixed-y-force-layout.html
+++ b/fixed-y-force-layout.html
@@ -120,8 +120,28 @@
         } else {
           return el.height - el.margin / 2;
         }
-      }
+      },
 
-    });  
+      getColorByNode: function(node) {
+        var group = node.group;
+        var color = "rgb(55, 71, 79)";
+        switch(group) {
+          case 1:
+            color = "blue";
+            break;
+          case 2:
+            color = "green";
+            break;
+          case 3:
+            color = "yellow";
+            break;
+          case 4:
+            color = "red";
+            break;
+        }
+        return color;
+      },
+
+    });
   </script>
 </polymer-element>

--- a/force-layout-component.html
+++ b/force-layout-component.html
@@ -529,7 +529,7 @@
         var nodeCircle = el.stage.selectAll(".node circle");
         nodeCircle.attr("cx", function(d) { return d.x; })
                   .attr("cy", function(d) { return el.getYByNode(d); })
-                  .style("fill", groupColor);
+                  .style("fill", this.getColorByNode);
 
         var nodeTitle = el.stage.selectAll(".node text");
         nodeTitle.attr("x", function(d) { return d.x; })
@@ -539,6 +539,26 @@
 
       getYByNode: function(node) {
         return node.y;
+      },
+
+      getColorByNode: function(node) {
+        var group = node.group;
+        var color = "rgb(55, 71, 79)";
+        switch(group) {
+          case 1:
+            color = "blue";
+            break;
+          case 2:
+            color = "green";
+            break;
+          case 3:
+            color = "yellow";
+            break;
+          case 4:
+            color = "red";
+            break;
+        }
+        return color;
       },
 
       update: function() {
@@ -614,7 +634,7 @@
 
         var node = nodeEnterGroup.append("circle")
           .attr("r", 10)
-          .style("fill", groupColor);
+          .style("fill", this.getColorByNode);
 
         var title = nodeEnterGroup.append("text")
           .attr("dx", 10)
@@ -730,26 +750,6 @@
       },//end update
 
     });
-
-    function groupColor(n) {
-      var group = n.group;
-      var color = "rgb(55, 71, 79)";
-      switch(group) {
-        case 1:
-          color = "blue";
-          break;
-        case 2:
-          color = "green";
-          break;
-        case 3:
-          color = "yellow";
-          break;
-        case 4:
-          color = "red";
-          break;
-      }
-      return color;
-    }
 
     // function updateNode(el) {
     //   el.stage.selectAll(".node")

--- a/force-layout-component.html
+++ b/force-layout-component.html
@@ -542,23 +542,7 @@
       },
 
       getColorByNode: function(node) {
-        var group = node.group;
-        var color = "rgb(55, 71, 79)";
-        switch(group) {
-          case 1:
-            color = "blue";
-            break;
-          case 2:
-            color = "green";
-            break;
-          case 3:
-            color = "yellow";
-            break;
-          case 4:
-            color = "red";
-            break;
-        }
-        return color;
+        return "rgb(55, 71, 79)";
       },
 
       update: function() {


### PR DESCRIPTION
## Why
- ノードの色を決める関数がグローバル関数だった
- `force-layout-component` で `node.group` によって色を決めていた
## How
- ノードの色を決める関数をローカル変数に
- `force-layout-component` のノードの色を決める関数をデフォルト色のみを返す関数に
- `fixed-y-force-layout` でノードの色を決める関数をオーバーライドして `node.group` によって色を決めるようにした
